### PR TITLE
[BE | DA] Integrate backend and data analysis components for sleep prediction

### DIFF
--- a/backend/src/main/java/com/vitametrics/vitametrics/global/AppConfig.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/global/AppConfig.java
@@ -1,0 +1,15 @@
+package com.vitametrics.vitametrics.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+}

--- a/backend/src/main/java/com/vitametrics/vitametrics/global/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/global/GlobalExceptionHandler.java
@@ -3,13 +3,19 @@ package com.vitametrics.vitametrics.global;
 import com.vitametrics.vitametrics.sleep.exception.SleepRecordException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(value = {SleepRecordException.TemporalOrderException.class})
+    @ExceptionHandler(value = {SleepRecordException.TemporalOrderException.class,
+            SleepRecordException.InvalidDateFormatException.class})
     public ResponseEntity<ErrorResponse> handleCustomBadRequestException(final RuntimeException exception) {
         return buildErrorResponse(exception.getMessage(), HttpStatus.BAD_REQUEST);
     }
@@ -17,6 +23,27 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {SleepRecordException.NonExistSleepRecordException.class})
     public ResponseEntity<ErrorResponse> handleCustomNotFoundException(final RuntimeException exception) {
         return buildErrorResponse(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = {SleepRecordException.WrongSleepDurationFormatException.class,
+            SleepRecordException.InvalidTimeFormatException.class})
+    public ResponseEntity<ErrorResponse> handleCustomBadGateException(final RuntimeException exception) {
+        return buildErrorResponse(exception.getMessage(), HttpStatus.BAD_GATEWAY);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, List<ValidationErrorResponse>>> handleValidationException(final MethodArgumentNotValidException exception) {
+        List<ValidationErrorResponse> errors = exception.getBindingResult().getFieldErrors().stream()
+                .map(error -> new ValidationErrorResponse(
+                        error.getField(),
+                        error.getDefaultMessage(),
+                        error.getRejectedValue()))
+                .toList();
+
+        Map<String, List<ValidationErrorResponse>> response = new HashMap<>();
+        response.put("errors", errors);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(final String message, final HttpStatus status) {

--- a/backend/src/main/java/com/vitametrics/vitametrics/global/ValidationErrorResponse.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/global/ValidationErrorResponse.java
@@ -1,0 +1,8 @@
+package com.vitametrics.vitametrics.global;
+
+public record ValidationErrorResponse(
+        String field,
+        String message,
+        Object rejectedValue
+) {
+}

--- a/backend/src/main/java/com/vitametrics/vitametrics/sleep/application/SleepPredictionService.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/sleep/application/SleepPredictionService.java
@@ -1,0 +1,54 @@
+package com.vitametrics.vitametrics.sleep.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionRequest;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionResponse;
+import com.vitametrics.vitametrics.sleep.exception.SleepRecordException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class SleepPredictionService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${django.api.url}")
+    String djangoApiUrl;
+
+    public SleepPredictionResponse getSleepPrediction(final SleepPredictionRequest request) {
+        final String url = UriComponentsBuilder.fromHttpUrl(djangoApiUrl)
+                .path("/api/sleep/predict")
+                .toUriString();
+
+        HttpEntity<String> entity = buildRequestEntity(request);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+        return SleepPredictionResponse.parse(response.getBody());
+
+    }
+
+    private HttpEntity<String> buildRequestEntity(final SleepPredictionRequest request) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            String jsonBody = objectMapper.writeValueAsString(request);
+
+            return new HttpEntity<>(jsonBody, headers);
+        } catch (JsonProcessingException e) {
+            throw new SleepRecordException.InvalidDateFormatException(request.date());
+        }
+    }
+
+}

--- a/backend/src/main/java/com/vitametrics/vitametrics/sleep/application/dto/SleepPredictionRequest.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/sleep/application/dto/SleepPredictionRequest.java
@@ -1,0 +1,16 @@
+package com.vitametrics.vitametrics.sleep.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SleepPredictionRequest(
+
+        @Pattern(
+                regexp = "\\d{4}-\\d{2}-\\d{2}",
+                message = "Invalid date format. Expected format: yyyy-MM-dd"
+
+        )
+        @NotBlank(message = "Date must not be blank")
+        String date
+) {
+}

--- a/backend/src/main/java/com/vitametrics/vitametrics/sleep/application/dto/SleepPredictionResponse.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/sleep/application/dto/SleepPredictionResponse.java
@@ -1,0 +1,37 @@
+package com.vitametrics.vitametrics.sleep.application.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vitametrics.vitametrics.sleep.exception.SleepRecordException;
+
+public record SleepPredictionResponse(
+        int hours,
+        int minutes
+) {
+
+    public static final int MIN_HOUR = 0;
+    public static final int MAX_HOUR = 23;
+    public static final int MIN_MINUTES = 0;
+    public static final int MAX_MINUTES = 59;
+
+    public static SleepPredictionResponse parse(String response) {
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            SleepPredictionResponse parsedResponse = mapper.readValue(response, SleepPredictionResponse.class);
+            validate(parsedResponse);
+            return parsedResponse;
+        } catch (JsonProcessingException e) {
+                throw new SleepRecordException.WrongSleepDurationFormatException(response);
+        }
+    }
+
+    private static void validate(SleepPredictionResponse response) {
+        if (response.hours() < MIN_HOUR || response.hours() > MAX_HOUR) {
+            throw new SleepRecordException.InvalidTimeFormatException(response.hours(), response.minutes());
+        }
+        if (response.minutes() < MIN_MINUTES || response.minutes() > MAX_MINUTES) {
+            throw new SleepRecordException.InvalidTimeFormatException(response.hours(), response.minutes());
+        }
+    }
+}

--- a/backend/src/main/java/com/vitametrics/vitametrics/sleep/exception/SleepRecordException.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/sleep/exception/SleepRecordException.java
@@ -8,7 +8,6 @@ public class SleepRecordException extends RuntimeException {
         super(message);
     }
 
-
     public static class TemporalOrderException extends SleepRecordException {
         public TemporalOrderException(LocalDateTime bedTime, LocalDateTime wakeTime) {
             super(String.format("Invalid temporal order: bedTime (%s) is after wakeTime (%s)", bedTime, wakeTime));
@@ -20,6 +19,30 @@ public class SleepRecordException extends RuntimeException {
             super(String.format(
                     "sleep record not found - request details {sleep_record_id: %d}", sleepRecordId)
             );
+        }
+    }
+
+    public static class WrongSleepDurationFormatException extends SleepRecordException {
+        public WrongSleepDurationFormatException(String response) {
+            super(String.format(
+                    "Fail to parse response: " + response
+            ));
+        }
+    }
+
+    public static class InvalidTimeFormatException extends SleepRecordException {
+        public InvalidTimeFormatException(int hours, int minutes) {
+            super(String.format(
+                    "Invalid time format: (%d)hour (%d)minutes", hours, minutes)
+            );
+        }
+    }
+
+    public static class InvalidDateFormatException extends SleepRecordException {
+        public InvalidDateFormatException(String date) {
+            super(String.format(
+                    "Invalid date format: %s, ", date
+            ));
         }
     }
 

--- a/backend/src/main/java/com/vitametrics/vitametrics/sleep/presentation/SleepPredictionController.java
+++ b/backend/src/main/java/com/vitametrics/vitametrics/sleep/presentation/SleepPredictionController.java
@@ -1,0 +1,26 @@
+package com.vitametrics.vitametrics.sleep.presentation;
+
+import com.vitametrics.vitametrics.sleep.application.SleepPredictionService;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionRequest;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/sleep")
+@RequiredArgsConstructor
+public class SleepPredictionController {
+
+    private final SleepPredictionService sleepPredictionService;
+
+    @GetMapping(value = "/predict-sleep", params = "date")
+    public ResponseEntity<SleepPredictionResponse> getPrediction(@Valid SleepPredictionRequest request) {
+        SleepPredictionResponse sleepPrediction = sleepPredictionService.getSleepPrediction(request);
+        return ResponseEntity.ok(sleepPrediction);
+    }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  profiles:
+    active: local
+
+  # for test
+  h2:
+    console:
+      enabled: true
+  datasource:
+    # for test
+    url: jdbc:h2:~/Vitametircs;MODE=MySQL
+    username: sa
+    password:
+    hikari:
+      maximum-pool-size: 5
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop # for test
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true # for test
+    show-sql: true # for test
+
+
+django:
+  api:
+    url: "http://localhost:8000"

--- a/backend/src/test/java/com/vitametrics/vitametrics/common/fixtures/acceptance/SleepPredictionAcceptanceFixture.java
+++ b/backend/src/test/java/com/vitametrics/vitametrics/common/fixtures/acceptance/SleepPredictionAcceptanceFixture.java
@@ -1,0 +1,21 @@
+package com.vitametrics.vitametrics.common.fixtures.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class SleepPredictionAcceptanceFixture {
+
+    private static final String BASE_URL = "/api/sleep";
+
+    public static ExtractableResponse<Response> GET_SLEEP_PREDICTION_REQUEST(String predictionDate) {
+        return RestAssured.given().log().all()
+                .queryParam("date", predictionDate)
+                .when().log().all()
+                .get(BASE_URL + "/predict-sleep")
+                .then().log().all()
+                .extract();
+
+
+    }
+}

--- a/backend/src/test/java/com/vitametrics/vitametrics/learning/MockLearningTest.java
+++ b/backend/src/test/java/com/vitametrics/vitametrics/learning/MockLearningTest.java
@@ -1,0 +1,245 @@
+package com.vitametrics.vitametrics.learning;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vitametrics.vitametrics.sleep.application.SleepPredictionService;
+import com.vitametrics.vitametrics.sleep.application.SleepRecordService;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionRequest;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionResponse;
+import com.vitametrics.vitametrics.sleep.exception.SleepRecordException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.mockito.Mockito.*;
+
+public class MockLearningTest {
+
+    @Autowired
+    SleepPredictionService realService;
+
+
+    @Test
+    void shouldReturnStubbedValue() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+        SleepPredictionRequest request = new SleepPredictionRequest("2024-11-17");
+        int expectedHours = 7;
+        int expectedMinutes = 50;
+        SleepPredictionResponse expectedResponse = new SleepPredictionResponse(expectedHours, expectedMinutes);
+        when(mockService.getSleepPrediction(request)).thenReturn(expectedResponse);
+
+        // Act
+        SleepPredictionResponse response = mockService.getSleepPrediction(new SleepPredictionRequest("2024-11-17"));
+
+        // Assert
+        Assertions.assertThat(response.hours()).isEqualTo(expectedHours);
+        Assertions.assertThat(response.minutes()).isEqualTo(expectedMinutes);
+
+    }
+
+    @Test
+    void shouldVerifyMethodCall() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+        SleepPredictionRequest request = new SleepPredictionRequest("2024-11-17");
+
+        // Act
+        mockService.getSleepPrediction(request);
+
+        // Assert
+
+        /**
+         * 	•	Mockito ensures that:
+         * 	•	The method processData was called.
+         * 	•	The argument passed to the method was ""2024-11-17"".
+         */
+        verify(mockService).getSleepPrediction(new SleepPredictionRequest("2024-11-17"));
+    }
+
+    @Test
+    void shouldStubWithArgumentMatcher() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+        int expectedHours = 7;
+        int expectedMinutes = 50;
+        SleepPredictionResponse expectedResponse = new SleepPredictionResponse(expectedHours, expectedMinutes);
+
+        /**
+         * 	•	anyString():
+         * 	    •	Matches any String argument passed to the method.
+         * 	    •	Allows flexibility in tests where the exact argument value doesn’t matter.
+         * 	•	anyInt(): Matches any int value.
+         * 	•	any(): Matches any object of any type.
+         * 	•	eq("value"): Matches the exact value "value".
+         */
+        when(mockService.getSleepPrediction(any())).thenReturn(expectedResponse);
+
+        // Act
+        mockService.getSleepPrediction(new SleepPredictionRequest("2024-11-11"));
+
+        // Assert
+        Assertions.assertThat(expectedResponse.hours()).isEqualTo(expectedHours);
+        Assertions.assertThat(expectedResponse.minutes()).isEqualTo(expectedMinutes);
+    }
+
+    @Test
+    void shouldVerifyNumberOfInteractions() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+        SleepPredictionRequest request = new SleepPredictionRequest("2024-11-17");
+
+        // Act
+        mockService.getSleepPrediction(request);
+        mockService.getSleepPrediction(request);
+
+        // Assert
+        verify(mockService, times(2)).getSleepPrediction(new SleepPredictionRequest("2024-11-17"));
+    }
+
+    @Test
+    void shouldThrowExceptionOnStubbedCall() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+        String invalidDate = "2024-13-10";
+        SleepPredictionRequest invalidRequest = new SleepPredictionRequest(invalidDate);
+        when(mockService.getSleepPrediction(invalidRequest)).thenThrow(new SleepRecordException.InvalidDateFormatException(invalidDate));
+
+        // Act & Assert
+        Assertions.assertThatThrownBy(() -> mockService.getSleepPrediction(invalidRequest))
+                .isInstanceOf(SleepRecordException.InvalidDateFormatException.class);
+    }
+
+    @Test
+    void shouldStubUsingDoReturn() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+        SleepPredictionRequest request = new SleepPredictionRequest("2024-11-17");
+
+        int expectedHours = 7;
+        int expectedMinutes = 50;
+        SleepPredictionResponse expectedResponse = new SleepPredictionResponse(expectedHours, expectedMinutes);
+
+        /**
+         *  Why Use doReturn Instead of when?
+         *
+         *  1. Final Methods
+         *      •	If the method being stubbed is final, when(...).thenReturn(...) will fail with a MockitoException.
+         *
+         *  2. Void Methods
+         *      •	For methods with a void return type, you can use doReturn alongside doNothing() or doThrow().
+         */
+        doReturn(expectedResponse).when(mockService).getSleepPrediction(request);
+
+        // Act
+        SleepPredictionResponse response = mockService.getSleepPrediction(request);
+
+        // Assert
+        Assertions.assertThat(response.hours()).isEqualTo(expectedHours);
+        Assertions.assertThat(response.minutes()).isEqualTo(expectedMinutes);
+    }
+
+    @Test
+    void shouldVerifyNoInteractions() {
+        // Arrange
+        SleepPredictionService mockService = mock(SleepPredictionService.class);
+
+        // Assert
+        verifyNoInteractions(mockService);
+    }
+
+    @Test
+    void shouldCaptureArgument() throws JsonProcessingException {
+        // Arrange
+        ObjectMapper mockObjectMapper = mock(ObjectMapper.class);
+        RestTemplate mockRestTemplate = mock(RestTemplate.class);
+
+        SleepPredictionService sleepPredictionService = new SleepPredictionService(mockRestTemplate, mockObjectMapper);
+        ReflectionTestUtils.setField(sleepPredictionService, "djangoApiUrl", "http://localhost:8000");
+
+        SleepPredictionRequest request = new SleepPredictionRequest("2024-11-17");
+        ArgumentCaptor<HttpEntity<String>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        when(mockObjectMapper.writeValueAsString(request)).thenReturn("{\"date\": \"2024-11-17\"}");
+        when(mockRestTemplate.postForEntity(
+                eq("http://localhost:8000/api/sleep/predict"),
+                captor.capture(),
+                eq(String.class)
+        )).thenReturn(ResponseEntity.ok("{\"hours\": 7, \"minutes\": 50}"));
+
+
+        // Act
+        SleepPredictionResponse response = sleepPredictionService.getSleepPrediction(request);
+
+        // Verify
+        Assertions.assertThat(response.hours()).isEqualTo(7);
+        Assertions.assertThat(response.minutes()).isEqualTo(50);
+    }
+
+    @Test
+    void shouldUsePartialMockWithSpy() {
+        // Arrange
+        ObjectMapper objectMapper = new ObjectMapper();
+        RestTemplate restTemplate = new RestTemplate();
+        RestTemplate spyRestTemplate = spy(restTemplate);
+
+        SleepPredictionService sleepPredictionService = new SleepPredictionService(spyRestTemplate, objectMapper);
+        ReflectionTestUtils.setField(sleepPredictionService, "djangoApiUrl", "http://localhost:8000");
+
+        /**
+         *  •	spy(realService):
+         * 	    •	Wraps the real MyService object in a spy.
+         * 	    •	A spy behaves like the real object but allows selective stubbing of its methods.
+         * 	    •	Non-stubbed methods retain their original implementation.
+         */
+
+        SleepPredictionRequest request = new SleepPredictionRequest("2024-11-17");
+        int expectedHours = 7;
+        int expectedMinutes = 50;
+        SleepPredictionResponse expectedResponse = new SleepPredictionResponse(expectedHours, expectedMinutes);
+
+        /**
+         * 	•	doReturn(...).when(...).methodCall(...):
+         * 	    •	Stubs the getData("input") method on the spy to return "mocked value".
+         * 	    •	Unlike when(...).thenReturn(...), the doReturn(...).when(...) syntax is more appropriate for spies because it avoids invoking the actual method during stubbing.
+         */
+
+        ArgumentCaptor<HttpEntity<String>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+        doReturn(ResponseEntity.ok("{\"hours\": 7, \"minutes\": 50}")).when(spyRestTemplate).postForEntity(
+                eq("http://localhost:8000/api/sleep/predict"),
+                captor.capture(),
+                eq(String.class));
+
+        // Act
+        SleepPredictionResponse response = sleepPredictionService.getSleepPrediction(request);
+
+        // Assert
+        Assertions.assertThat(response.hours()).isEqualTo(expectedHours);
+        Assertions.assertThat(response.minutes()).isEqualTo(expectedMinutes);
+    }
+
+    @Test
+    void shouldStubbingVoidMethod() {
+        // Arrange
+        SleepRecordService mockService = mock(SleepRecordService.class);
+        Long sleepRecordId = 1L;
+
+        /**
+         * 	•	doNothing():
+         * 	    •	Specifies that the void method (deleteData) should do nothing when called.
+         * 	    •	This is the default behavior for void methods in Mockito, but explicitly stubbing it can improve clarity.
+         */
+        doNothing().when(mockService).delete(sleepRecordId);
+
+        // Act
+        mockService.delete(sleepRecordId);
+
+        // Assert
+        verify(mockService).delete(1L);
+    }
+}

--- a/backend/src/test/java/com/vitametrics/vitametrics/sleep/acceeptance/SleepPredictionAcceptanceTest.java
+++ b/backend/src/test/java/com/vitametrics/vitametrics/sleep/acceeptance/SleepPredictionAcceptanceTest.java
@@ -1,0 +1,89 @@
+package com.vitametrics.vitametrics.sleep.acceeptance;
+
+import com.vitametrics.vitametrics.common.AcceptanceTest;
+import com.vitametrics.vitametrics.common.fixtures.acceptance.SleepPredictionAcceptanceFixture;
+import com.vitametrics.vitametrics.sleep.application.SleepPredictionService;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionRequest;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionResponse;
+import com.vitametrics.vitametrics.sleep.presentation.SleepPredictionController;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static com.vitametrics.vitametrics.common.fixtures.acceptance.SleepPredictionAcceptanceFixture.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SleepPredictionAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private SleepPredictionController sleepPredictionController;
+
+    @Mock
+    private SleepPredictionService sleepPredictionService;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(sleepPredictionController, "sleepPredictionService", sleepPredictionService);
+    }
+
+    @Test
+    void shouldPredictSleepDuration() {
+        // given
+        String predictionDate = "2024-11-17";
+        SleepPredictionRequest request = new SleepPredictionRequest(predictionDate);
+        SleepPredictionResponse predictionResponse = new SleepPredictionResponse(7, 50);
+        when(sleepPredictionService.getSleepPrediction(request)).thenReturn(new SleepPredictionResponse(7, 50));
+
+        // when
+        ExtractableResponse<Response> response = GET_SLEEP_PREDICTION_REQUEST(predictionDate);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                    softly.assertThat(response.jsonPath().getInt("hours")).isEqualTo(predictionResponse.hours());
+                    softly.assertThat(response.jsonPath().getInt("minutes")).isEqualTo(predictionResponse.minutes());
+                }
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPredictingSleepDurationWithInvalidDateFormat() {
+        // given
+        String invalidDate = "2024";
+
+        // when
+        ExtractableResponse<Response> response = GET_SLEEP_PREDICTION_REQUEST(invalidDate);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            softly.assertThat(response.body().jsonPath().getString("errors[0].rejectedValue")).isEqualTo(invalidDate);
+            softly.assertThat(response.body().jsonPath().getString("errors[0].message")).isEqualTo("Invalid date format. Expected format: yyyy-MM-dd");
+        });
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPredictingSleepDurationWithEmptyDateValue() {
+        // given
+        String invalidDate = "";
+
+        // when
+        ExtractableResponse<Response> response = GET_SLEEP_PREDICTION_REQUEST(invalidDate);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            softly.assertThat(response.body().jsonPath().getString("errors[0].message")).isEqualTo("Date must not be blank");
+        });
+    }
+}

--- a/backend/src/test/java/com/vitametrics/vitametrics/sleep/application/SleepPredictionServiceTest.java
+++ b/backend/src/test/java/com/vitametrics/vitametrics/sleep/application/SleepPredictionServiceTest.java
@@ -1,0 +1,90 @@
+package com.vitametrics.vitametrics.sleep.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vitametrics.vitametrics.common.ServiceTest;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionRequest;
+import com.vitametrics.vitametrics.sleep.application.dto.SleepPredictionResponse;
+import com.vitametrics.vitametrics.sleep.exception.SleepRecordException;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.mockito.Mockito.*;
+
+class SleepPredictionServiceTest extends ServiceTest {
+
+    private SleepPredictionService sleepPredictionService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+        sleepPredictionService = new SleepPredictionService(restTemplate, objectMapper);
+        ReflectionTestUtils.setField(sleepPredictionService, "djangoApiUrl", "http://localhost:8000");
+    }
+
+    @Test
+    void shouldGetSleepPrediction() throws JsonProcessingException {
+        // given
+        String date = "2024-11-17";
+        SleepPredictionRequest request = new SleepPredictionRequest(date);
+        SleepPredictionResponse expectedResponse = new SleepPredictionResponse(7, 50);
+
+        String mockJsonResponse = "{\"hours\": 7, \"minutes\": 50}";
+        ArgumentCaptor<HttpEntity<String>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        when(restTemplate.postForEntity(
+                eq("http://localhost:8000/api/sleep/predict"),
+                captor.capture(),
+                eq(String.class)
+        )).thenReturn(ResponseEntity.ok(mockJsonResponse));
+
+        // when
+        SleepPredictionResponse response = sleepPredictionService.getSleepPrediction(request);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(response).isNotNull();
+                    softly.assertThat(response.hours()).isEqualTo(expectedResponse.hours());
+                    softly.assertThat(response.minutes()).isEqualTo(expectedResponse.minutes());
+
+                }
+        );
+
+        verify(restTemplate, times(1)).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenGettingSleepPredictionWithInvalidResponse() {
+
+        // given
+        String date = "2024-11-17";
+        SleepPredictionRequest request = new SleepPredictionRequest(date);
+
+        String invalidResponseBody = "notDateFormat";
+        ArgumentCaptor<HttpEntity<String>> captor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        when(restTemplate.postForEntity(
+                eq("http://localhost:8000/api/sleep/predict"),
+                captor.capture(),
+                eq(String.class)
+        )).thenReturn(ResponseEntity.ok(invalidResponseBody));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> sleepPredictionService.getSleepPrediction(request))
+                .isInstanceOf(SleepRecordException.WrongSleepDurationFormatException.class)
+                .hasMessage("Fail to parse response: " + invalidResponseBody);
+    }
+}

--- a/data_analysis/vitametric_analysis/sleep_analysis/service.py
+++ b/data_analysis/vitametric_analysis/sleep_analysis/service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 import joblib
 import pandas as pd
 
@@ -6,7 +7,8 @@ import pandas as pd
 class SleepAnalysisService:
 
     def __init__(self):
-        self.model = self.load_model('/Users/the9kim/VitaMetrics/data_analysis/vitametric_analysis/sleep_prediction_model.pkl')
+        self.model = self.load_model(
+            '/Users/the9kim/VitaMetrics/data_analysis/vitametric_analysis/sleep_prediction_model.pkl')
 
     @staticmethod
     def load_model(model_path):
@@ -15,9 +17,10 @@ class SleepAnalysisService:
         except FileNotFoundError:
             raise Exception(f"Model file not found at path: {model_path}")
 
-    def predict_sleep_duration(self, date: str) -> str:
-        date_obj = pd.to_datetime(date, errors='coerce')
-        if pd.isnull(date_obj):
+    def predict_sleep_duration(self, date: str) -> dict[str, int]:
+        try:
+            date_obj = datetime.strptime(date, '%Y-%m-%d')  # Ensure 'YYYY-MM-DD' format
+        except ValueError:
             raise ValueError("Invalid Date format. Use 'YYYY-MM-DD'.")
 
         input_data = self._prepare_input(date_obj)
@@ -46,18 +49,13 @@ class SleepAnalysisService:
         return sleep_data
 
     @staticmethod
-    def _format_prediction(predicted_minutes: float) -> str:
+    def _format_prediction(predicted_minutes: float) -> dict[str, int]:
         hours = int(predicted_minutes // 60)
         minutes = int(predicted_minutes % 60)
+        return {"hours": hours, "minutes": minutes}
 
-        return f"The expected sleep duration is {hours} hours and {minutes} minutes"
 
 if __name__ == '__main__':
-
     service = SleepAnalysisService()
-    prediction = service.predict_sleep_duration('2024.11.17')
+    prediction = service.predict_sleep_duration('2024-11-17')
     print(prediction)
-
-
-
-

--- a/data_analysis/vitametric_analysis/sleep_analysis/views.py
+++ b/data_analysis/vitametric_analysis/sleep_analysis/views.py
@@ -1,8 +1,12 @@
-from django.http import JsonResponse
 import json
+
+from django.http import JsonResponse
+from rest_framework.decorators import api_view
+
 from .service import SleepAnalysisService
 
 
+@api_view(['POST'])
 def predict_sleep_duration(request):
     try:
         data = json.loads(request.body)
@@ -17,11 +21,11 @@ def predict_sleep_duration(request):
         if prediction is None:
             return JsonResponse({'error': 'No sleep records found'}, status=404)
 
-        return JsonResponse({'predicted sleep': prediction})
+        return JsonResponse({'hours': prediction['hours'], 'minutes': prediction['minutes']})
+
 
     except ValueError:
         return JsonResponse({'error': 'Invalid date format. Expected format: YYYY-MM-DD'}, status=400)
 
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=500)
-


### PR DESCRIPTION
## Description
- Backend
    -  Redirect sleep prediction requests from the frontend to the data analysis component using Spring RestTemplate.
    -  Return the sleep prediction values(in HH:mm format) generated by the data analysis component to the frontend using json format.
    -  Validate the interaction between frontend to data analysis component.
- Data Analysis
    - Predict sleeping duration Using XGBoost model based on the date value as an input.
    - Return the predicted sleep duration in HH:mm format to the backend.
    - Validate the input and output data formats.


## Related Issue

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] ETC